### PR TITLE
修改地图参数: ze_frostdrake_tower_v1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_frostdrake_tower_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_frostdrake_tower_v1.cfg
@@ -23,7 +23,7 @@ mp_timelimit "45"
 // 说  明: 回合时间 (分钟)
 // 最小值: 1
 // 最大值: 60
-mp_roundtime "15.0"
+mp_roundtime "60.0"
 
 
 ///
@@ -58,7 +58,7 @@ store_thirdperson_enabled "1"
 // 说  明: 根据尸变指数降序来选择母体僵尸<关闭则使用纯随机> (开关)
 // 最小值: 0
 // 最大值: 1
-ze_infection_sort_by_keephuman_desc "0"
+ze_infection_sort_by_keephuman_desc "1"
 
 // 说  明: 尸变比 (人)
 // 最小值: 1
@@ -248,7 +248,7 @@ ze_weapons_round_hegrenade "8"
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "1"
+ze_weapons_round_molotov "2"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
@@ -298,7 +298,7 @@ sm_boomer_distance "300.0"
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0
 // 最大值: 9999.9
-sm_smoker_distance "300.0"
+sm_smoker_distance "500.0"
 
 // 说  明: 跳刀伤害 (Unit)
 // 最小值: 30.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_frostdrake_tower_v1
## 为什么要增加/修改这个东西
增加回合时间，防止没打完就结束；修改尸变为指数尸变，随机尸变可能导致有人卡尸变，一直是僵尸；参数回滚至2月份的参数，钩子僵尸已被更新
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
