### PR TITLE
修改地图参数: ze_aot_trost_v8_3

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_aot_trost_v8_3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_aot_trost_v8_3.cfg
@@ -58,7 +58,7 @@ store_thirdperson_enabled "1"
 // 说  明: 根据尸变指数降序来选择母体僵尸<关闭则使用纯随机> (开关)
 // 最小值: 0
 // 最大值: 1
-ze_infection_sort_by_keephuman_desc "1"
+ze_infection_sort_by_keephuman_desc "0"
 
 // 说  明: 尸变比 (人)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_aot_trost_v8_3
## 为什么要增加/修改这个东西
增加地图的公平对抗性，根据守则，拥有皮肤的地图通常需要打开随机尸变模式
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
