### PR TITLE
修改地图参数: ze_boatescape_ultimate_t2f5

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_boatescape_ultimate_t2f5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_boatescape_ultimate_t2f5.cfg
@@ -33,7 +33,7 @@ mp_roundtime "60.0"
 // 说  明: VIP延长投票 (次)
 // 最小值: 0
 // 最大值: 2
-vips_map_extend_times "1"
+vips_map_extend_times "2"
 
 // 说  明: MCR延长投票 (次)
 // 最小值: 0
@@ -108,12 +108,12 @@ ze_damage_shop_credit "24000"
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 1
 // 最大值: 30
-ze_credits_pass_round "3"
+ze_credits_pass_round "5"
 
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "6"
+rank_ze_win_points_humans "2"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_boatescape_ultimate_t2f5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_boatescape_ultimate_t2f5.cfg
@@ -108,12 +108,12 @@ ze_damage_shop_credit "24000"
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 1
 // 最大值: 30
-ze_credits_pass_round "5"
+ze_credits_pass_round "4"
 
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "2"
+rank_ze_win_points_humans "4"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_boatescape_ultimate_t2f5.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_boatescape_ultimate_t2f5.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "0"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "7"
+zr_infect_mzombie_ratio "6"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_boatescape_ultimate_t2f5
## 为什么要增加/修改这个东西
削减云点奖励，根据单局时长增加1vip延长
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
