### PR TITLE
修改地图参数: ze_obj_filth_v1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_filth_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_filth_v1.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "1"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "8"
+zr_infect_mzombie_ratio "7"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "17.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.1"
+zr_knockback_multi "1.0"
 
 
 ///
@@ -238,12 +238,12 @@ ze_weapons_spawn_molotov "1"
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "12"
+ze_weapons_round_hegrenade "10"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -258,7 +258,7 @@ ze_weapons_round_decoy "6"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "1"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1
@@ -288,12 +288,12 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.2"
+sm_faster_maxspeed "1.4"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0
 // 最大值: 999.9
-sm_boomer_distance "100.0"
+sm_boomer_distance "150.0"
 
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0
@@ -318,7 +318,7 @@ sm_finger_distance "150.0"
 // 说  明: 缴械连锁 (人)
 // 最小值: 1
 // 最大值: 8
-sm_deimos_targetfx "2"
+sm_deimos_targetfx "3"
 
 // 说  明: 缴械掉落 (0-无, 1-主武器, 2-主武器+任意手雷, 3-主武器+所有手雷
 // 最小值: 0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_filth_v1
## 为什么要增加/修改这个东西
第一版平衡效果不理想，根据实战情况再次削弱人类参数数值，因禁用刀锋和长手僵尸，增强部分其他僵尸技能参数保证平衡。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
