### PR TITLE
修改地图参数: ze_obj_nirvana_a4

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_nirvana_a4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_nirvana_a4.cfg
@@ -73,17 +73,17 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "17.0"
+zr_infect_spawntime_max "12.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "17.0"
+zr_infect_spawntime_min "12.0"
 
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.5"
+zr_knockback_multi "1.3"
 
 
 ///
@@ -93,7 +93,7 @@ zr_knockback_multi "1.5"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.9"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 9999.0
@@ -238,27 +238,27 @@ ze_weapons_spawn_molotov "1"
 // 说  明: 每局开始时补给的冰冻数量 (个)
 // 最小值: 0
 // 最大值: 1
-ze_weapons_spawn_decoy "1"
+ze_weapons_spawn_decoy "0"
 
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_hegrenade "14"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_molotov "9"
+ze_weapons_round_molotov "8"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_decoy "8"
+ze_weapons_round_decoy "7"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 10
-ze_weapons_round_flash "3"
+ze_weapons_round_flash "2"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1
@@ -273,7 +273,7 @@ ze_weapons_round_tagrenade "1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 5
-ze_weapons_round_healshot "3"
+ze_weapons_round_healshot "5"
 
 
 ///
@@ -288,12 +288,12 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.2"
+sm_faster_maxspeed "1.5"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0
 // 最大值: 999.9
-sm_boomer_distance "150.0"
+sm_boomer_distance "200.0"
 
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_nirvana_a4
## 为什么要增加/修改这个东西
1、调整尸变倒计时以防止人类提前部署进僵尸复活点刷死母体僵尸；
2、第一版参数为开荒参数，目前通关率相对较高，根据实战情况适当降低人类参数（击退值、打钱比、道具数目上限），加强部分僵尸的技能数值以保证平衡。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
