### PR TITLE
修改地图参数: ze_magic_carpet_p2

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_magic_carpet_p2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_magic_carpet_p2.cfg
@@ -118,7 +118,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "10"
+rank_ze_win_points_humans "8"
 
 
 ///


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_magic_carpet_p2
## 为什么要增加/修改这个东西
该咸鱼图流程短，且通关率极高，人类获胜所得基本云点偏高，且与保底积分不匹配，故调整基础云点10至8，以平衡该图收益。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
