### PR TITLE
修改地图参数: ze_obj_vertigo_v3_2

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_vertigo_v3_2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_vertigo_v3_2.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "17.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.2"
+zr_knockback_multi "1.0"
 
 // 说  明: 母体在传送点多少单位附近属于保护距离(u)
 // 最小值: 0.0
@@ -253,17 +253,17 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "14"
+ze_weapons_round_hegrenade "10"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_molotov "8"
+ze_weapons_round_molotov "6"
 
 // 说  明: 每局最多可购买的冰冻数量 (个)
 // 最小值: -1
 // 最大值: 15
-ze_weapons_round_decoy "6"
+ze_weapons_round_decoy "4"
 
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
@@ -298,7 +298,7 @@ sm_hunter_leappower "160.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.6"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_vertigo_v3_2
## 为什么要增加/修改这个东西
该图目前通关率高，且在此参数下人类方人少的情况下仍然可以通过后期憋的大量道具和地形优势达成胜利，故减少人类道具量上限，提高加速僵尸追尾能力以达成平衡。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
