### PR TITLE
修改地图参数: ze_avalanche_reboot_k1

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_avalanche_reboot_k1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_avalanche_reboot_k1.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "20.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.1"
+zr_knockback_multi "1.0"
 
 // 说  明: 母体在传送点多少单位附近属于保护距离(u)
 // 最小值: 0.0
@@ -113,12 +113,12 @@ ze_damage_shop_credit "20000"
 // 说  明: 通关所获得的积分 (积分)
 // 最小值: 1
 // 最大值: 30
-ze_credits_pass_round "4"
+ze_credits_pass_round "5"
 
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "7"
+rank_ze_win_points_humans "10"
 
 
 ///
@@ -298,7 +298,7 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.6"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_avalanche_reboot_k1
## 为什么要增加/修改这个东西
测试地图参数调整，因神器较为强势暂时适当下降击退和其他参数平衡。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
