### PR TITLE
修改地图参数: ze_multimaps

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_blackout_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_blackout_v1.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "20.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.2"
+zr_knockback_multi "1.0"
 
 // 说  明: 母体在传送点多少单位附近属于保护距离(u)
 // 最小值: 0.0
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "4"
+ze_weapons_round_healshot "6"
 
 
 ///
@@ -298,7 +298,7 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.5"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_filth_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_filth_v1.cfg
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "16"
+ze_weapons_round_hegrenade "13"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -298,7 +298,7 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.5"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_infiltration_b3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_infiltration_b3.cfg
@@ -98,7 +98,7 @@ ze_protection_mzombie_distance "256.0"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.6"
+ze_damage_zombie_cash "0.8"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 9999.0
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "15"
+ze_weapons_round_hegrenade "8"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_insane_v1_2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_insane_v1_2.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "20.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.3"
+zr_knockback_multi "1.2"
 
 // 说  明: 母体在传送点多少单位附近属于保护距离(u)
 // 最小值: 0.0
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "18"
+ze_weapons_round_hegrenade "13"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -293,7 +293,7 @@ ze_weapons_round_healshot "4"
 // 说  明: 闪灵冲刺推力 (Unit)
 // 最小值: 150.0
 // 最大值: 500.0
-sm_hunter_leappower "170.0"
+sm_hunter_leappower "150.0"
 
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_nirvana_v1fix.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_nirvana_v1fix.cfg
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "17"
+ze_weapons_round_hegrenade "14"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -268,7 +268,7 @@ ze_weapons_round_decoy "7"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 12
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "5"
+ze_weapons_round_healshot "6"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v1_4.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v1_4.cfg
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "17"
+ze_weapons_round_hegrenade "13"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "4"
+ze_weapons_round_healshot "6"
 
 
 ///
@@ -298,7 +298,7 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.5"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_npst_v2.cfg
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "16"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rampage_v1_2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rampage_v1_2.cfg
@@ -98,7 +98,7 @@ ze_protection_mzombie_distance "256.0"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.7"
+ze_damage_zombie_cash "0.9"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 9999.0
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "16"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "5"
+ze_weapons_round_healshot "6"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_rescape_v1.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "18.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.2"
+zr_knockback_multi "1.0"
 
 // 说  明: 母体在传送点多少单位附近属于保护距离(u)
 // 最小值: 0.0
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "17"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -268,7 +268,7 @@ ze_weapons_round_decoy "5"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 12
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_vertigo_v3_2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_vertigo_v3_2.cfg
@@ -98,7 +98,7 @@ ze_protection_mzombie_distance "256.0"
 // 说  明: 伤害与金钱转化比例 ($)
 // 最小值: 0.1
 // 最大值: 3.0
-ze_damage_zombie_cash "0.6"
+ze_damage_zombie_cash "0.7"
 
 // 说  明: 伤害云点转化比例 (云点)
 // 最小值: 9999.0
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "0"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "18"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -268,7 +268,7 @@ ze_weapons_round_decoy "6"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 12
-ze_weapons_round_flash "2"
+ze_weapons_round_flash "3"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "4"
+ze_weapons_round_healshot "5"
 
 
 ///

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_void_b4_t2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_void_b4_t2.cfg
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "16"
+ze_weapons_round_hegrenade "12"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -283,7 +283,7 @@ ze_weapons_round_tagrenade "-1"
 // 说  明: 每局最多可购买的血针数量 (支)
 // 最小值: -1
 // 最大值: 8
-ze_weapons_round_healshot "4"
+ze_weapons_round_healshot "5"
 
 
 ///
@@ -298,7 +298,7 @@ sm_hunter_leappower "150.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.5"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_multimaps
## 为什么要增加/修改这个东西
人类枪械击退较为强势，加上圣光雷后守点压力十分轻松，根据9月13号晚上十一点测试的filth实战，调整圣光雷为燃烧雷后参数较为平衡化，故提交第二版改动，减少人类高爆总道具上限，调整所有地图的圣光雷为燃烧雷，恢复部分地图的加速僵尸倍率，根据实战情况调整部分地图的打钱比和击退值。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
