### PR TITLE
修改地图参数: ze_endemic_v1_3

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -8815,9 +8815,9 @@
         "m_MinPlayers"        "40"
         "m_MaxPlayers"        "0"
         "m_MaxCooldown"       "70"
-        "m_NominateOnly"      "1"
+        "m_NominateOnly"      "0"
         "m_VipOnly"           "0"
-        "m_AdminOnly"         "1"
+        "m_AdminOnly"         "0"
         "m_RefundRatio"       "0.5"
     }
 }

--- a/ZombiEscape/addons/sourcemod/configs/mapdata.kv
+++ b/ZombiEscape/addons/sourcemod/configs/mapdata.kv
@@ -8815,7 +8815,7 @@
         "m_MinPlayers"        "40"
         "m_MaxPlayers"        "0"
         "m_MaxCooldown"       "70"
-        "m_NominateOnly"      "0"
+        "m_NominateOnly"      "1"
         "m_VipOnly"           "0"
         "m_AdminOnly"         "0"
         "m_RefundRatio"       "0.5"

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_endemic_v1_3.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_endemic_v1_3.cfg
@@ -73,12 +73,12 @@ zr_infect_mzombie_respawn "1"
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_min同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_max "10.0"
+zr_infect_spawntime_max "12.0"
 
 // 说  明: 尸变倒计时<须与zr_infect_spawntime_max同步> (秒)
 // 最小值: 1
 // 最大值: 90
-zr_infect_spawntime_min "10.0"
+zr_infect_spawntime_min "12.0"
 
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
@@ -118,7 +118,7 @@ ze_credits_pass_round "4"
 // 说  明: 通关获得多少云点<人类>
 // 最小值: 1
 // 最大值: 30
-rank_ze_win_points_humans "12"
+rank_ze_win_points_humans "9"
 
 
 ///
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "2"
+ze_grenade_nade_cfeffect "3"
 
 
 ///
@@ -253,7 +253,7 @@ ze_weapons_spawn_decoy "1"
 // 说  明: 每局最多可购买的高爆数量 (个)
 // 最小值: -1
 // 最大值: 20
-ze_weapons_round_hegrenade "4"
+ze_weapons_round_hegrenade "5"
 
 // 说  明: 每局最多可购买的火瓶数量 (个)
 // 最小值: -1
@@ -268,7 +268,7 @@ ze_weapons_round_decoy "2"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 12
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "-1"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1
@@ -293,7 +293,7 @@ ze_weapons_round_healshot "2"
 // 说  明: 闪灵冲刺推力 (Unit)
 // 最小值: 150.0
 // 最大值: 500.0
-sm_hunter_leappower "250.0"
+sm_hunter_leappower "200.0"
 
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
@@ -303,12 +303,12 @@ sm_faster_maxspeed "1.6"
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0
 // 最大值: 999.9
-sm_boomer_distance "160.0"
+sm_boomer_distance "300.0"
 
 // 说  明: 勾搭范围 (Unit)
 // 最小值: 100.0
 // 最大值: 9999.9
-sm_smoker_distance "275.0"
+sm_smoker_distance "175.0"
 
 // 说  明: 跳刀伤害 (Unit)
 // 最小值: 30.0
@@ -318,7 +318,7 @@ sm_blader_damage "45.0"
 // 说  明: 毒烟半径 (Unit)
 // 最小值: 50.0
 // 最大值: 9999.9
-sm_farter_distance "250.0"
+sm_farter_distance "200.0"
 
 // 说  明: 长手射程 (Unit)
 // 最小值: 150.0
@@ -340,10 +340,10 @@ sm_deimos_droptype "1"
 // 最大值: 9999.9
 sm_coffin_radius "100.0"
 
-zr_class_modify "普通僵尸" "health_regen_amount" "20"
-zr_class_modify "加速僵尸" "health_regen_amount" "20"
-zr_class_modify "闪灵僵尸" "health_regen_amount" "20"
-zr_class_modify "唾沫僵尸" "health_regen_amount" "20"
-zr_class_modify "母体僵尸" "health_regen_amount" "20"
+zr_class_modify "普通僵尸" "health_regen_amount" "10"
+zr_class_modify "加速僵尸" "health_regen_amount" "10"
+zr_class_modify "闪灵僵尸" "health_regen_amount" "10"
+zr_class_modify "唾沫僵尸" "health_regen_amount" "10"
+zr_class_modify "母体僵尸" "health_regen_amount" "10"
 
 Echo "Executed config for ze_endemic_v1_3."


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_endemic_v1_3
## 为什么要增加/修改这个东西
测图时僵尸参数过于强大，一半人去打超车僵尸还是有点吃力。开局尸变过快，导致抓人，地图流程7-8 分钟，但是不可能50人过关，削弱云点，超车僵尸没有圣光雷，地形过于狭窄，旋转跳无解
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
