### PR TITLE
修改地图参数: ze_obj_horizons_a2

### DIFF
--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_horizons_a2.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_obj_horizons_a2.cfg
@@ -83,7 +83,7 @@ zr_infect_spawntime_min "20.0"
 // 说  明: 全局击退系数 (%)
 // 最小值: 0.1
 // 最大值: 1.5
-zr_knockback_multi "1.2"
+zr_knockback_multi "0.8"
 
 // 说  明: 母体在传送点多少单位附近属于保护距离(u)
 // 最小值: 0.0
@@ -218,7 +218,7 @@ ze_savelevel_multis "0"
 // 说  明: 高爆模式, 0为禁用, 1 = 燃烧, 2 = 减速, 3 = 击退 (开关)
 // 最小值: 0
 // 最大值: 3
-ze_grenade_nade_cfeffect "3"
+ze_grenade_nade_cfeffect "1"
 
 
 ///
@@ -268,7 +268,7 @@ ze_weapons_round_decoy "7"
 // 说  明: 每局最多可购买的屏障数量 (个)
 // 最小值: -1
 // 最大值: 12
-ze_weapons_round_flash "1"
+ze_weapons_round_flash "2"
 
 // 说  明: 每局最多可购买的磁暴数量 (个)
 // 最小值: -1
@@ -298,7 +298,7 @@ sm_hunter_leappower "160.0"
 // 说  明: 加速暴发冲力 (%)
 // 最小值: 1.1
 // 最大值: 2.0
-sm_faster_maxspeed "1.4"
+sm_faster_maxspeed "1.6"
 
 // 说  明: 唾液射程 (Unit)
 // 最小值: 100.0


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_obj_horizons_a2
## 为什么要增加/修改这个东西
根据8F实战情况人类方压力较小，结合守点地形较为狭窄的情况，把圣光雷修改成燃烧雷，削弱人类击退，增强僵尸追尾能力。
## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
