### PR TITLE
修改地图参数: ze_aot_trost_v6_2r

### DIFF
--- a/ZombiEscape/addons/sourcemod/configs/bosshp/ze_aot_trost_v6_2r.cfg
+++ b/ZombiEscape/addons/sourcemod/configs/bosshp/ze_aot_trost_v6_2r.cfg
@@ -11,7 +11,14 @@
         {
             "iterator"      "lv5_boss_counter"
             "hitbox"        "lv5_boss_hitbox"
-            "displayname"   "巨人"
+            "displayname"   "超大型巨人"
+        }
+        
+        "2"
+        {
+            "iterator"      "eatmother_counter"
+            "hitbox"        "eatmother_hitbox"
+            "displayname"   "戴娜巨人"
         }
         
     }

--- a/ZombiEscape/cfg/sourcemod/map-configs/ze_aot_trost_v6_2r.cfg
+++ b/ZombiEscape/cfg/sourcemod/map-configs/ze_aot_trost_v6_2r.cfg
@@ -63,7 +63,7 @@ ze_infection_sort_by_keephuman_desc "0"
 // 说  明: 尸变比 (人)
 // 最小值: 1
 // 最大值: 32
-zr_infect_mzombie_ratio "8"
+zr_infect_mzombie_ratio "7"
 
 // 说  明: 尸变时传送回出生点 (开关)
 // 最小值: 0
@@ -228,7 +228,7 @@ ze_grenade_nade_cfeffect "1"
 // 说  明: 每局最大可购买的Awp数量 (把)
 // 最小值: 1
 // 最大值: 64
-ze_weapons_awp_counts "3"
+ze_weapons_awp_counts "2"
 
 // 说  明: 每局最大可购买的SSG数量 (把)
 // 最小值: 1


### PR DESCRIPTION
## 该PR作用的地图是(仅英文小写)
ze_aot_trost_v6_2r

## 为什么要增加/修改这个东西
修正第五关妈巨不显示反馈的问题，同时减少尸变比，使第五关僵尸神器能拿全，并根据过往对局减少一把大狙的数量，适当提高一定程度高跳的操作空间

## 在提交PR前请确认已完成以下工作
- 我已经阅读了``OP手册`` 和 ``参数修改公约``.
- 我已经遵守了手册和公约的指导.
- 我已经自检过以确认没有错误的符号拼写和非法字符.
- 我已经按照公约的要求正确填写PR的标题.
- 我在提交PR前已将分支更新到最新.
- 我确认该PR中仅包含一张地图的内容.
